### PR TITLE
Fix Nice!view pins

### DIFF
--- a/boards/shields/cardinal/cardinal.dtsi
+++ b/boards/shields/cardinal/cardinal.dtsi
@@ -111,16 +111,16 @@
 
     spi1_default: spi1_default {
         group1 {
-            psels = <NRF_PSEL(SPIM_SCK, 0, 6)>,
+            psels = <NRF_PSEL(SPIM_SCK, 0, 17)>,
                     <NRF_PSEL(SPIM_MOSI, 0, 8)>,
-                    <NRF_PSEL(SPIM_MISO, 0, 17)>;
+                    <NRF_PSEL(SPIM_MISO, 0, 25)>;
         };
     };
     spi1_sleep: spi1_sleep {
         group1 {
-            psels = <NRF_PSEL(SPIM_SCK, 0, 6)>,
+            psels = <NRF_PSEL(SPIM_SCK, 0, 17)>,
                     <NRF_PSEL(SPIM_MOSI, 0, 8)>,
-                    <NRF_PSEL(SPIM_MISO, 0, 17)>;
+                    <NRF_PSEL(SPIM_MISO, 0, 25)>;
             low-power-enable;
         };
     };


### PR DESCRIPTION
SCK and CS pins were swapped. MISO pin is not used on other nice!view configuration examples.